### PR TITLE
Add parameters and send results to villas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+
+all:
+	make -C image

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,11 +1,20 @@
 
-FROM sogno/dpsim:latest
+FROM sogno/dpsim:dev
 
-# install dpsimpy
-RUN rm -rf /dpsim/build && mkdir /dpsim/build
+RUN yum -y install python3-pip
+RUN pip3 install pika build
+
+RUN git clone https://github.com/sogno-platform/dpsim /dpsim
+RUN mkdir /dpsim/build && cd /dpsim/build
 WORKDIR /dpsim
 RUN python3 -m build --wheel
 RUN python3 -m pip install ./dist/dpsim*
+
+WORKDIR /dpsim/build
+RUN cmake -DWITH_PYBIND=ON -DDPSIM_BUILD_EXAMPLES=OFF -DGET_GRID_DATA=OFF .. && make
+RUN cp /dpsim/build/dpsimpyvillas*.so /usr/local/lib64/python3.9/site-packages/
+
+WORKDIR /dpsim
 
 RUN pip install pika
 COPY send_request.py receive.py /usr/bin/
@@ -15,5 +24,6 @@ RUN chown -R user /etc/config
 RUN mkdir -p /run
 RUN chown user /run
 USER user
+
 WORKDIR /run
 CMD [ "/usr/bin/receive.py" ]

--- a/image/Makefile
+++ b/image/Makefile
@@ -1,4 +1,6 @@
+
+MINIKUBE_IP:=$(shell minikube ip)
 all:
-	docker build -t dpsim .
-	docker tag dpsim localhost:5000/dpsim:worker
-	docker push localhost:5000/dpsim:worker
+	docker build -t dpsim:worker .
+	docker tag dpsim:worker ${MINIKUBE_IP}:5000/dpsim:worker
+	docker push ${MINIKUBE_IP}:5000/dpsim:worker


### PR DESCRIPTION

This change adds the following parameters to the simulation:
* domain
* solver
* timestep
* finaltime

Results are also uploaded to villas via mqtt using the dpsimpyvillas Python library. The Dockerfile has been updated to build this.

This requires the corresponding changes in the dpsim-examples project that starts the "mosquitto" server.
 
Signed-off-by: Richard Marston <rmarston@eonerc.rwth-aachen.de>